### PR TITLE
Generate skeleton code of a plugin for golangci-lint

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ pkgname
 ├── cmd
 │   └── pkgname
 │       └── main.go
+├── plugin
+│   └── pkgname
+│       └── main.go
 ├── pkgname.go
 ├── pkgname_test.go
 └── testdata
@@ -38,6 +41,12 @@ pkgname
 ```
 $ skeleton -path="github.com/gostaticanalysis/pkgname"
 pkgname
+├── cmd
+│   └── pkgname
+│       └── main.go
+├── plugin
+│   └── pkgname
+│       └── main.go
 ├── pkgname.go
 ├── pkgname_test.go
 └── testdata
@@ -51,10 +60,39 @@ pkgname
 ```
 $ skeleton -cmd=false pkgname
 pkgname
+├── plugin
+│   └── pkgname
+│       └── main.go
 ├── pkgname.go
 ├── pkgname_test.go
 └── testdata
     └── src
         └── a
             └── a.go
+```
+
+### Create skeleton codes without plugin directory
+
+```
+$ skeleton -cmd=false pkgname
+pkgname
+├── cmd
+│   └── pkgname
+│       └── main.go
+├── pkgname.go
+├── pkgname_test.go
+└── testdata
+    └── src
+        └── a
+            └── a.go
+```
+
+## Build as a plugin for golangci-lint
+
+`skeleton` generates plugin directory which has main.go.
+The main.go can be built as a plugin for [golangci-lint](https://golangci-lint.run/contributing/new-linters/#how-to-add-a-private-linter-to-golangci-lint).
+
+```
+$ skeleton pkgname
+$ go build -buildmode=plugin -o path_to_plugin_dir importpath
 ```

--- a/main.go
+++ b/main.go
@@ -15,6 +15,7 @@ import (
 func main() {
 	var s Skeleton
 	flag.BoolVar(&s.Cmd, "cmd", true, "create cmd directory")
+	flag.BoolVar(&s.Plugin, "plugin", true, "create plugin directory")
 	flag.StringVar(&s.ImportPath, "path", "", "import path")
 	flag.Parse()
 	s.ExeName = os.Args[0]
@@ -35,6 +36,7 @@ type Skeleton struct {
 	ExeName    string
 	Args       []string
 	Cmd        bool
+	Plugin bool
 	ImportPath string
 }
 
@@ -107,6 +109,12 @@ func (s *Skeleton) Run() error {
 		}
 	}
 
+	if s.Plugin {
+		if err := s.createPlugin(dir, &info); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 
@@ -147,6 +155,25 @@ func (s *Skeleton) createCmd(dir string, info *PkgInfo) error {
 	defer cmdMain.Close()
 
 	if err := cmdMainTempl.Execute(cmdMain, info); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (s *Skeleton) createPlugin(dir string, info *PkgInfo) error {
+	pluginDir := filepath.Join(dir, "plugin", info.Pkg)
+	if err := os.MkdirAll(pluginDir, 0777); err != nil {
+		return err
+	}
+
+	pluginMain, err := os.Create(filepath.Join(pluginDir, "main.go"))
+	if err != nil {
+		return err
+	}
+	defer pluginMain.Close()
+
+	if err := pluginMainTempl.Execute(pluginMain, info); err != nil {
 		return err
 	}
 

--- a/template.go
+++ b/template.go
@@ -78,3 +78,26 @@ import (
 
 func main() { unitchecker.Main({{.Pkg}}.Analyzer) }
 `))
+
+var pluginMainTempl = template.Must(template.New("main.go").Parse(`// This file can build as a plugin for golangci-lint by below command.
+//    go build -buildmode=plugin -o path_to_plugin_dir {{.ImportPath}}/plugin/{{.Pkg}}
+// See: https://golangci-lint.run/contributing/new-linters/#how-to-add-a-private-linter-to-golangci-lint
+
+package main
+
+import (
+	"{{.ImportPath}}"
+	"golang.org/x/tools/go/analysis"
+)
+
+// AnalyzerPlugin provides analyzers as a plugin.
+// It follows golangci-lint style plugin.
+var AnalyzerPlugin analyzerPlugin
+
+type analyzerPlugin struct{}
+func (analyzerPlugin) GetAnalyzers() []*analysis.Analyzer {
+	return []*analysis.Analyzer{
+		{{.Pkg}}.Analyzer,
+	}
+}
+`))


### PR DESCRIPTION
This PR makes  `skeleton` can generate plugin directory which has main.go.
The main.go can be built as a plugin for [golangci-lint](https://golangci-lint.run/contributing/new-linters/#how-to-add-a-private-linter-to-golangci-lint).

```
$ skeleton pkgname
$ go build -buildmode=plugin -o path_to_plugin_dir importpath
```