### PR TITLE
Fix go version logic

### DIFF
--- a/v2/go.mod
+++ b/v2/go.mod
@@ -3,17 +3,17 @@ module github.com/gostaticanalysis/skeleton/v2
 go 1.23.3
 
 require (
-	github.com/gostaticanalysis/skeletonkit v0.4.0
+	github.com/gostaticanalysis/skeletonkit v0.4.1
 	github.com/tenntenn/golden v0.2.0
-	golang.org/x/mod v0.21.0
+	golang.org/x/mod v0.22.0
 )
 
 require (
 	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/josharian/mapfs v0.0.0-20210615234106-095c008854e6 // indirect
 	github.com/josharian/txtarfs v0.0.0-20240408113805-5dc76b8fe6bf // indirect
-	golang.org/x/sync v0.8.0 // indirect
-	golang.org/x/tools v0.26.0 // indirect
+	golang.org/x/sync v0.9.0 // indirect
+	golang.org/x/tools v0.27.0 // indirect
 )
 
 retract v2.1.1

--- a/v2/go.sum
+++ b/v2/go.sum
@@ -2,6 +2,8 @@ github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/gostaticanalysis/skeletonkit v0.4.0 h1:dHR48OSGfrbA6G36W5wd6TuY6w6Gooi4hRrvxa5uH9o=
 github.com/gostaticanalysis/skeletonkit v0.4.0/go.mod h1:UcRLvBDmeN7krfn6gM2W58XEA5IzjHxtX1NLGR3p2CM=
+github.com/gostaticanalysis/skeletonkit v0.4.1 h1:22ImX8zqtjDGfvQZYwJvtVR6ff6JwG4jQLIigZGpNto=
+github.com/gostaticanalysis/skeletonkit v0.4.1/go.mod h1:ep5WlFfwr3pi3erF3rcpyobHmyle9aLLbKCAacBRGc4=
 github.com/josharian/mapfs v0.0.0-20210615234106-095c008854e6 h1:c+ctPFdISggaSNCfU1IueNBAsqetJSvMcpQlT+0OVdY=
 github.com/josharian/mapfs v0.0.0-20210615234106-095c008854e6/go.mod h1:Rv/momJI8DgrWnBZip+SgagpcgORIZQE5SERlxNb8LY=
 github.com/josharian/txtarfs v0.0.0-20240408113805-5dc76b8fe6bf h1:ZWuoyLMwZvLJ6OHUhPq1sZHa37Pikt6DXkZPhhOBzEE=
@@ -15,6 +17,8 @@ golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.21.0 h1:vvrHzRwRfVKSiLrG+d4FMl/Qi4ukBCE6kZlTUkDYRT0=
 golang.org/x/mod v0.21.0/go.mod h1:6SkKJ3Xj0I0BrPOZoBy3bdMptDDU9oJrpohJ3eWZ1fY=
+golang.org/x/mod v0.22.0 h1:D4nJWe9zXqHOmWqj4VMOJhvzj7bEZg4wEYa759z1pH4=
+golang.org/x/mod v0.22.0/go.mod h1:6SkKJ3Xj0I0BrPOZoBy3bdMptDDU9oJrpohJ3eWZ1fY=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
@@ -22,6 +26,8 @@ golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.8.0 h1:3NFvSEYkUoMifnESzZl15y791HH1qU2xm6eCJU5ZPXQ=
 golang.org/x/sync v0.8.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
+golang.org/x/sync v0.9.0 h1:fEo0HyrW1GIgZdpbhCRO0PkJajUS5H9IFUztCgEo2jQ=
+golang.org/x/sync v0.9.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -33,6 +39,8 @@ golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.1.0/go.mod h1:xkSsbof2nBLbhDlRMhhhyNLN/zl3eTqcnHD5viDpcZ0=
 golang.org/x/tools v0.26.0 h1:v/60pFQmzmT9ExmjDv2gGIfi3OqfKoEP6I5+umXlbnQ=
 golang.org/x/tools v0.26.0/go.mod h1:TPVVj70c7JJ3WCazhD8OdXcZg/og+b9+tH/KxylGwH0=
+golang.org/x/tools v0.27.0 h1:qEKojBykQkQ4EynWy4S8Weg69NumxKdn40Fce3uc/8o=
+golang.org/x/tools v0.27.0/go.mod h1:sUi0ZgbwW9ZPAq26Ekut+weQPR5eIM6GQLQ1Yjm1H0Q=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/v2/skeleton/testdata/kind-codegen-go118.golden
+++ b/v2/skeleton/testdata/kind-codegen-go118.golden
@@ -151,7 +151,7 @@ func TestGenerator(t *testing.T) {
 -- example/go.mod --
 module example.com/example
 
-go 1.23
+go 1.23.3
 
 -- example/testdata/src/a/a.go --
 package a
@@ -202,5 +202,5 @@ func (m *MockLogger) Infof(format string, args ...any) {
 -- example/testdata/src/a/go.mod --
 module a
 
-go 1.23
+go 1.23.3
 

--- a/v2/skeleton/testdata/kind-codegen.golden
+++ b/v2/skeleton/testdata/kind-codegen.golden
@@ -151,7 +151,7 @@ func TestGenerator(t *testing.T) {
 -- example/go.mod --
 module example.com/example
 
-go 1.23
+go 1.23.3
 
 -- example/testdata/src/a/a.go --
 package a
@@ -202,5 +202,5 @@ func (m *MockLogger) Infof(format string, args ...interface{}) {
 -- example/testdata/src/a/go.mod --
 module a
 
-go 1.23
+go 1.23.3
 

--- a/v2/skeleton/testdata/kind-inspect-go118.golden
+++ b/v2/skeleton/testdata/kind-inspect-go118.golden
@@ -67,7 +67,7 @@ func TestAnalyzer(t *testing.T) {
 -- example/go.mod --
 module example.com/example
 
-go 1.23
+go 1.23.3
 
 -- example/testdata/src/a/a.go --
 package a
@@ -80,5 +80,5 @@ func f() {
 -- example/testdata/src/a/go.mod --
 module a
 
-go 1.23
+go 1.23.3
 

--- a/v2/skeleton/testdata/kind-inspect.golden
+++ b/v2/skeleton/testdata/kind-inspect.golden
@@ -67,7 +67,7 @@ func TestAnalyzer(t *testing.T) {
 -- example/go.mod --
 module example.com/example
 
-go 1.23
+go 1.23.3
 
 -- example/testdata/src/a/a.go --
 package a
@@ -80,5 +80,5 @@ func f() {
 -- example/testdata/src/a/go.mod --
 module a
 
-go 1.23
+go 1.23.3
 

--- a/v2/skeleton/testdata/kind-packages-go118.golden
+++ b/v2/skeleton/testdata/kind-packages-go118.golden
@@ -228,7 +228,7 @@ func pkgname(pkg *packages.Package) string {
 -- example/go.mod --
 module example.com/example
 
-go 1.23
+go 1.23.3
 
 -- example/internal/analyzer.go --
 package internal
@@ -358,5 +358,5 @@ func f() {
 -- example/testdata/src/a/go.mod --
 module a
 
-go 1.23
+go 1.23.3
 

--- a/v2/skeleton/testdata/kind-packages.golden
+++ b/v2/skeleton/testdata/kind-packages.golden
@@ -228,7 +228,7 @@ func pkgname(pkg *packages.Package) string {
 -- example/go.mod --
 module example.com/example
 
-go 1.23
+go 1.23.3
 
 -- example/internal/analyzer.go --
 package internal
@@ -358,5 +358,5 @@ func f() {
 -- example/testdata/src/a/go.mod --
 module a
 
-go 1.23
+go 1.23.3
 

--- a/v2/skeleton/testdata/kind-ssa-go118.golden
+++ b/v2/skeleton/testdata/kind-ssa-go118.golden
@@ -66,7 +66,7 @@ func TestAnalyzer(t *testing.T) {
 -- example/go.mod --
 module example.com/example
 
-go 1.23
+go 1.23.3
 
 -- example/testdata/src/a/a.go --
 package a
@@ -79,5 +79,5 @@ func f() {
 -- example/testdata/src/a/go.mod --
 module a
 
-go 1.23
+go 1.23.3
 

--- a/v2/skeleton/testdata/kind-ssa.golden
+++ b/v2/skeleton/testdata/kind-ssa.golden
@@ -66,7 +66,7 @@ func TestAnalyzer(t *testing.T) {
 -- example/go.mod --
 module example.com/example
 
-go 1.23
+go 1.23.3
 
 -- example/testdata/src/a/a.go --
 package a
@@ -79,5 +79,5 @@ func f() {
 -- example/testdata/src/a/go.mod --
 module a
 
-go 1.23
+go 1.23.3
 

--- a/v2/skeleton/testdata/nocmd.golden
+++ b/v2/skeleton/testdata/nocmd.golden
@@ -60,7 +60,7 @@ func TestAnalyzer(t *testing.T) {
 -- example/go.mod --
 module example.com/example
 
-go 1.23
+go 1.23.3
 
 -- example/testdata/src/a/a.go --
 package a
@@ -73,5 +73,5 @@ func f() {
 -- example/testdata/src/a/go.mod --
 module a
 
-go 1.23
+go 1.23.3
 

--- a/v2/skeleton/testdata/nooption.golden
+++ b/v2/skeleton/testdata/nooption.golden
@@ -67,7 +67,7 @@ func TestAnalyzer(t *testing.T) {
 -- example/go.mod --
 module example.com/example
 
-go 1.23
+go 1.23.3
 
 -- example/testdata/src/a/a.go --
 package a
@@ -80,5 +80,5 @@ func f() {
 -- example/testdata/src/a/go.mod --
 module a
 
-go 1.23
+go 1.23.3
 

--- a/v2/skeleton/testdata/onlypkgname.golden
+++ b/v2/skeleton/testdata/onlypkgname.golden
@@ -69,7 +69,7 @@ func TestAnalyzer(t *testing.T) {
 -- example/go.mod --
 module example
 
-go 1.23
+go 1.23.3
 
 -- example/testdata/src/a/a.go --
 package a
@@ -82,5 +82,5 @@ func f() {
 -- example/testdata/src/a/go.mod --
 module a
 
-go 1.23
+go 1.23.3
 

--- a/v2/skeleton/testdata/overwrite-cancel.golden
+++ b/v2/skeleton/testdata/overwrite-cancel.golden
@@ -77,5 +77,5 @@ func f() {
 -- example/testdata/src/a/go.mod --
 module a
 
-go 1.23
+go 1.23.3
 

--- a/v2/skeleton/testdata/overwrite-confirm-no.golden
+++ b/v2/skeleton/testdata/overwrite-confirm-no.golden
@@ -77,5 +77,5 @@ func f() {
 -- example/testdata/src/a/go.mod --
 module a
 
-go 1.23
+go 1.23.3
 

--- a/v2/skeleton/testdata/overwrite-confirm-yes.golden
+++ b/v2/skeleton/testdata/overwrite-confirm-yes.golden
@@ -67,7 +67,7 @@ func TestAnalyzer(t *testing.T) {
 -- example/go.mod --
 module example.com/example
 
-go 1.23
+go 1.23.3
 
 -- example/testdata/src/a/a.go --
 package a
@@ -80,5 +80,5 @@ func f() {
 -- example/testdata/src/a/go.mod --
 module a
 
-go 1.23
+go 1.23.3
 

--- a/v2/skeleton/testdata/overwrite-force.golden
+++ b/v2/skeleton/testdata/overwrite-force.golden
@@ -67,7 +67,7 @@ func TestAnalyzer(t *testing.T) {
 -- example/go.mod --
 module example.com/example
 
-go 1.23
+go 1.23.3
 
 -- example/testdata/src/a/a.go --
 package a
@@ -80,5 +80,5 @@ func f() {
 -- example/testdata/src/a/go.mod --
 module a
 
-go 1.23
+go 1.23.3
 

--- a/v2/skeleton/testdata/overwrite-newonly.golden
+++ b/v2/skeleton/testdata/overwrite-newonly.golden
@@ -77,5 +77,5 @@ func f() {
 -- example/testdata/src/a/go.mod --
 module a
 
-go 1.23
+go 1.23.3
 

--- a/v2/skeleton/testdata/parent-module-deep.golden
+++ b/v2/skeleton/testdata/parent-module-deep.golden
@@ -77,5 +77,5 @@ func f() {
 -- subsub/testdata/src/a/go.mod --
 module a
 
-go 1.23
+go 1.23.3
 

--- a/v2/skeleton/testdata/parent-module.golden
+++ b/v2/skeleton/testdata/parent-module.golden
@@ -77,5 +77,5 @@ func f() {
 -- sub/testdata/src/a/go.mod --
 module a
 
-go 1.23
+go 1.23.3
 

--- a/v2/skeleton/testdata/plugin.golden
+++ b/v2/skeleton/testdata/plugin.golden
@@ -67,7 +67,7 @@ func TestAnalyzer(t *testing.T) {
 -- example/go.mod --
 module example.com/example
 
-go 1.23
+go 1.23.3
 
 -- example/plugin/main.go --
 // This file can build as a plugin for golangci-lint by below command.
@@ -117,5 +117,5 @@ func f() {
 -- example/testdata/src/a/go.mod --
 module a
 
-go 1.23
+go 1.23.3
 


### PR DESCRIPTION
The latest go version logic get from `runtime.Version()` which is Go's version at compile time.
The new logic get from `go env GOVERSION` in working directory.

Related #70 